### PR TITLE
Restrict Climate File service domain

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/python/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3.10

--- a/htdocs/dl/climatefile.py
+++ b/htdocs/dl/climatefile.py
@@ -13,7 +13,7 @@ def spiral(lon, lat):
     # points near the domain edge need to seach a bit further than 0.25deg
     X = 40
     Y = 40
-    for _ in range(40 ** 2):
+    for _ in range(40**2):
         if (-X / 2 < x <= X / 2) and (-Y / 2 < y <= Y / 2):
             newfn = get_cli_fname(lon + x * 0.01, lat + y * 0.01)
             if os.path.isfile(newfn):
@@ -34,6 +34,11 @@ def application(environ, start_response):
         headers = [("Content-type", "text/plain")]
         start_response("500 Internal Server Error", headers)
         return [b"API FAIL!"]
+    # 23 Jun 2022 restrict domain to decent data bounds
+    if lon < -104 or lon > -74 or lat < 35 or lat > 49:
+        headers = [("Content-type", "text/plain")]
+        start_response("500 Internal Server Error", headers)
+        return [b"Requested point outside of bounds -104,35 -74,49!"]
     fn = spiral(lon, lat)
     if fn is None:
         headers = [("Content-type", "text/plain")]


### PR DESCRIPTION
We are expanding the climate file domain, but it will take a number of moons to get those files up to a reasonable snuff.  So we should not let these files leak out via the API for now.