### PR TITLE
Require at least `date=` field

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.7.1"
+    rev: "v0.7.3"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/htdocs/geojson/huc12.py
+++ b/htdocs/geojson/huc12.py
@@ -18,9 +18,7 @@ class Schema(CGIModel):
     """See how we are called."""
 
     callback: str = Field(None, description="JSONP callback function")
-    date: datetime.date = Field(
-        datetime.date(2015, 5, 5), description="Date to query"
-    )
+    date: datetime.date = Field(..., description="Date to query")
     date2: datetime.date = Field(
         None, description="Optional end date to query"
     )


### PR DESCRIPTION
Addresses issue pointed out by @bkgelder that service will reply by with same data each time without a date= set.