### PR TITLE
📝 Fix typo with response schema

### DIFF
--- a/pylib/depbackend/auto/huc12data.py
+++ b/pylib/depbackend/auto/huc12data.py
@@ -44,7 +44,7 @@ def do(ts, ts2):
             WHERE valid >= :sdate and valid <= :edate
             and w.scenario_id = 0 GROUP by w.huc12_id)
 
-        SELECT h.huc12_code,
+        SELECT h.huc12_code as huc12,
         coalesce(round(d.avg_loss::numeric, 2), 0) as avg_loss,
         coalesce(round(d.qc_precip::numeric, 2), 0) as qc_precip,
         coalesce(round(d.avg_delivery::numeric, 2), 0) as avg_delivery,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the HUC12 identifier field in exported records, so the key now appears consistently as `huc12`.
  * Existing calculated values and summary metrics remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->